### PR TITLE
Add flipper-ui examples

### DIFF
--- a/examples/ui-postgres/Gemfile
+++ b/examples/ui-postgres/Gemfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+gem 'flipper'
+gem 'flipper-sequel'
+gem 'flipper-ui'
+gem 'pg'
+gem 'rack'
+gem 'sequel'
+gem 'webrick'

--- a/examples/ui-postgres/Gemfile.lock
+++ b/examples/ui-postgres/Gemfile.lock
@@ -1,0 +1,44 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    concurrent-ruby (1.2.2)
+    crass (1.0.6)
+    erubi (1.12.0)
+    flipper (0.26.0)
+      concurrent-ruby (< 2)
+    flipper-sequel (0.26.0)
+      flipper (~> 0.26.0)
+      sequel (>= 4.0.0, < 6)
+    flipper-ui (0.26.0)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.26.0)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, <= 4.0.0)
+      sanitize (< 7)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
+    pg (1.4.6)
+    racc (1.6.2)
+    rack (2.2.6.2)
+    rack-protection (3.0.5)
+      rack
+    sanitize (6.0.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    sequel (5.65.0)
+    webrick (1.8.1)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  flipper
+  flipper-sequel
+  flipper-ui
+  pg
+  rack
+  sequel
+  webrick
+
+BUNDLED WITH
+   2.3.15

--- a/examples/ui-postgres/README.md
+++ b/examples/ui-postgres/README.md
@@ -1,0 +1,10 @@
+# Web admin example
+
+Show how to use jnunemaker/flipper infrastructure to manage Redis flippers.
+
+## Usage
+
+1. Make sure you have Ruby + bundler installed.
+2. Set DATABASE_URL and HYAK_TABLE_PREFIX in env, see `./start`
+3. Issue `./start` at the shell to stand up a Rack-based web UI.
+4. Go to `http://127.0.0.1:9292` to see the web UI.

--- a/examples/ui-postgres/config.ru
+++ b/examples/ui-postgres/config.ru
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# https://www.flippercloud.io/docs/ui
+
+require 'sequel'
+
+# configure Sequel before requiring flipper-sequel
+DB = Sequel.connect ENV['DATABASE_URL']
+Sequel::Model.db = DB
+
+require 'flipper-ui'
+require 'flipper-sequel'
+
+# tell sequel about actual table names
+prefix = ENV['HYAK_TABLE_PREFIX']
+feature_table = "#{prefix}flipper_features".to_sym
+gate_table = "#{prefix}flipper_gates".to_sym
+class Feature < Sequel::Model(feature_table); end
+class Gate < Sequel::Model(gate_table); end
+
+adapter = Flipper::Adapters::Sequel.new(feature_class: Feature, gate_class: Gate)
+fstore = Flipper.new(adapter)
+
+Flipper::UI.configure do |config|
+  config.descriptions_source = lambda { |_keys|
+    { 'my:feature' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.' }
+  }
+
+  config.show_feature_description_in_list = true
+  config.banner_text = ENV['FLIPPER_BANNER']
+  # #{primary secondary success danger warning info light dark}
+  config.banner_class = ENV['FLIPPER_COLOR']
+  config.fun = true
+end
+
+run Flipper::UI.app(fstore) { |builder|
+  secret = ENV.fetch('SESSION_SECRET') { SecureRandom.hex(20) }
+  builder.use(Rack::Session::Cookie, secret:)
+  builder.use Rack::Auth::Basic do |_username, password|
+    password == 'secret'
+  end
+}
+
+# vt:ft=ruby

--- a/examples/ui-postgres/start
+++ b/examples/ui-postgres/start
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+if [[ "${TRACE-0}" == "1" ]]; then
+  set -o xtrace
+fi
+
+export FLIPPER_BANNER="hyak2 ui-postgres example"
+export FLIPPER_COLOR="primary"
+export DATABASE_URL="postgres://localhost:5432/hyak_test"
+export HYAK_TABLE_PREFIX="scratch_"
+export SESSION_SECRET=$(head -c20 /dev/urandom | base64)
+
+(sleep 1; open "http://localhost:9292") & # open web UI 1s after launch
+
+bundle exec rackup config.ru -p 9292

--- a/examples/ui-redis/Gemfile
+++ b/examples/ui-redis/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+gem 'flipper'
+gem 'flipper-redis'
+gem 'flipper-ui'
+gem 'rack'
+gem 'webrick'

--- a/examples/ui-redis/Gemfile.lock
+++ b/examples/ui-redis/Gemfile.lock
@@ -1,0 +1,45 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    concurrent-ruby (1.2.2)
+    connection_pool (2.3.0)
+    crass (1.0.6)
+    erubi (1.12.0)
+    flipper (0.26.0)
+      concurrent-ruby (< 2)
+    flipper-redis (0.26.0)
+      flipper (~> 0.26.0)
+      redis (>= 3.0, < 6)
+    flipper-ui (0.26.0)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.26.0)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, <= 4.0.0)
+      sanitize (< 7)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
+    racc (1.6.2)
+    rack (2.2.6.2)
+    rack-protection (3.0.5)
+      rack
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.12.2)
+      connection_pool
+    sanitize (6.0.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    webrick (1.8.1)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  flipper
+  flipper-redis
+  flipper-ui
+  rack
+  webrick
+
+BUNDLED WITH
+   2.3.15

--- a/examples/ui-redis/README.md
+++ b/examples/ui-redis/README.md
@@ -1,0 +1,10 @@
+# Web admin example
+
+Show how to use jnunemaker/flipper infrastructure to manage Redis flippers.
+
+## Usage
+
+1. Make sure you have Ruby + bundler installed.
+2. Set at least REDIS_URL in your shell environment, see `./start`
+3. Issue `./start` at the shell to stand up a Rack-based web UI.
+4. Go to `http://127.0.0.1:9292` to see the web UI.

--- a/examples/ui-redis/config.ru
+++ b/examples/ui-redis/config.ru
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# https://www.flippercloud.io/docs/ui
+
+require 'flipper-ui'
+require 'flipper/adapters/redis'
+
+options = {}
+
+options[:url] = ENV['REDIS_URL']
+options[:password] = ENV['REDIS_PASSWORD'] if ENV['REDIS_PASSWORD']
+# use below when eg. heroku gives self-signed rediss://
+# options[:ssl_params] = { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+
+client = Redis.new options
+adapter = Flipper::Adapters::Redis.new client
+fstore = Flipper.new(adapter)
+
+Flipper::UI.configure do |config|
+  config.descriptions_source = lambda { |_keys|
+    { 'my:feature' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.' }
+  }
+
+  config.show_feature_description_in_list = true
+  config.banner_text = ENV['FLIPPER_BANNER']
+  # #{primary secondary success danger warning info light dark}
+  config.banner_class = ENV['FLIPPER_COLOR']
+  config.fun = true
+end
+
+run Flipper::UI.app(fstore) { |builder|
+  secret = ENV.fetch('SESSION_SECRET') { SecureRandom.hex(20) }
+  builder.use(Rack::Session::Cookie, secret:)
+  builder.use Rack::Auth::Basic do |_username, password|
+    password == 'secret'
+  end
+}
+
+# vt:ft=ruby

--- a/examples/ui-redis/start
+++ b/examples/ui-redis/start
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+if [[ "${TRACE-0}" == "1" ]]; then
+  set -o xtrace
+fi
+
+export FLIPPER_BANNER="hyak2 ui-redis example"
+export FLIPPER_COLOR="primary"
+export REDIS_URL="redis://localhost:6379/1"
+export REDIS_PASSWORD="someredispassword"
+export SESSION_SECRET=$(head -c20 /dev/urandom | base64)
+
+(sleep 1; open "http://localhost:9292") & # open web UI 1s after launch
+
+bundle exec rackup config.ru -p 9292


### PR DESCRIPTION
Adds demonstrations of how to wire the stock Flipper web UI up with:

- the redis feature store with `flipper-redis`
- the postgres feature store using `flipper-sequel` and configuring a table prefix.