### PR TITLE
Fix bug with flipper-ui and postgres

### DIFF
--- a/modules/fstore-postgres/src/hyak2/postgres_store.clj
+++ b/modules/fstore-postgres/src/hyak2/postgres_store.clj
@@ -121,12 +121,12 @@
 (defn actor-gate-open? [gates akey]
   (->> gates
        (filter #(= (select-keys % [:key :value])
-                   {:key "actor" :value akey}))
+                   {:key "actors" :value akey}))
        seq boolean))
 
 (defn group-gate-open? [group-registry gates akey]
   (let [active-group? (->> gates
-                           (filter #(= (:key %) "group"))
+                           (filter #(= (:key %) "groups"))
                            (map :value)
                            (map keyword)
                            (into #{}))
@@ -213,14 +213,14 @@
   (-enable-actor! [_ fkey akey]
     (let [params (merge (make-names table-prefix)
                         {:fkey fkey
-                         :gate-type "actor"
+                         :gate-type "actors"
                          :gate-value akey})]
       (hug:insert-gate datasource params)))
 
   (-disable-actor! [_ fkey akey]
     (let [params (merge (make-names table-prefix)
                         {:fkey fkey
-                         :gate-type "actor"
+                         :gate-type "actors"
                          :gate-value akey})]
       (hug:delete-gate-for-fkey-key-val datasource params)))
 
@@ -236,14 +236,14 @@
   (-enable-group! [_ fkey gkey]
     (let [params (merge (make-names table-prefix)
                         {:fkey fkey
-                         :gate-type "group"
+                         :gate-type "groups"
                          :gate-value (name gkey)})]
       (hug:insert-gate datasource params)))
 
   (-disable-group! [_ fkey gkey]
     (let [params (merge (make-names table-prefix)
                         {:fkey fkey
-                         :gate-type "group"
+                         :gate-type "groups"
                          :gate-value (name gkey)})]
       (hug:delete-gate-for-fkey-key-val datasource params)))
 


### PR DESCRIPTION
This matches us up properly when using flipper against the same Postgres store. Flipper uses plurals for gate names ("actors", "groups") and this project was pointed at singulars ("actor", "group").

Result of this mismatch:

- If you enabled a feature via the repl, your feature would be on in the JVM but off in the flipper-ui.
- If you enabled a feature via flipper-ui, your feature would look like it was on in the UI but off in the JVM.
- Hijinks.